### PR TITLE
Allow guzzle 7.0 or 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "guzzlehttp/guzzle": "~6.0",
+        "guzzlehttp/guzzle": "^6.0|^7.0.1",
         "fabpot/goutte": "^4.0@dev"
     },
     "autoload": {


### PR DESCRIPTION
Enables support for Laravel 8.x